### PR TITLE
feat: Premium UI/UX enhancements (Source badges, Highlight matching, Animations)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import { Search, Loader2, FileText, Code2, BookOpen, Globe, ExternalLink, GitBranch, Video, MessageSquare, ArrowLeft } from 'lucide-react';
+import React, { useState, useEffect, useRef } from 'react';
+import { Search, Loader2, FileText, Code2, BookOpen, Globe, ExternalLink, GitBranch, Video, MessageSquare, ArrowLeft, SearchX, AlertCircle } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import clsx from 'clsx';
 import { twMerge } from 'tailwind-merge';
@@ -20,13 +20,45 @@ function getApiUrl() {
 }
 
 const TABS = [
-  { id: 'all',           label: 'All',           icon: Globe },
-  { id: 'wikipedia',     label: 'Wikipedia',     icon: BookOpen },
-  { id: 'stackoverflow', label: 'StackOverflow', icon: Code2 },
-  { id: 'github',        label: 'GitHub',        icon: GitBranch },
-  { id: 'reddit',        label: 'Reddit',        icon: MessageSquare },
-  { id: 'youtube',       label: 'YouTube',       icon: Video },
+  { id: 'all',           label: 'All',           icon: Globe,          color: '#40628A' },
+  { id: 'wikipedia',     label: 'Wikipedia',     icon: BookOpen,       color: '#1a6b3c' },
+  { id: 'stackoverflow', label: 'StackOverflow', icon: Code2,          color: '#e67e22' },
+  { id: 'github',        label: 'GitHub',        icon: GitBranch,      color: '#6e40c9' },
+  { id: 'reddit',        label: 'Reddit',        icon: MessageSquare,  color: '#ff4500' },
+  { id: 'youtube',       label: 'YouTube',       icon: Video,          color: '#c4302b' },
 ];
+
+// ─── SOURCE METADATA MAP ───────────────────────────────────────────────────────
+const SOURCE_META = {
+  wikipedia:     { label: 'Wikipedia',     color: '#1a6b3c', bg: 'rgba(26,107,60,0.08)',  border: 'rgba(26,107,60,0.18)',  icon: BookOpen },
+  stackoverflow: { label: 'StackOverflow', color: '#e67e22', bg: 'rgba(230,126,34,0.08)', border: 'rgba(230,126,34,0.18)', icon: Code2 },
+  github:        { label: 'GitHub',        color: '#6e40c9', bg: 'rgba(110,64,201,0.08)', border: 'rgba(110,64,201,0.18)', icon: GitBranch },
+  reddit:        { label: 'Reddit',        color: '#ff4500', bg: 'rgba(255,69,0,0.08)',   border: 'rgba(255,69,0,0.18)',   icon: MessageSquare },
+  youtube:       { label: 'YouTube',       color: '#c4302b', bg: 'rgba(196,48,43,0.08)',  border: 'rgba(196,48,43,0.18)',  icon: Video },
+  default:       { label: 'Web',           color: '#40628A', bg: 'rgba(64,98,138,0.08)',  border: 'rgba(64,98,138,0.18)',  icon: Globe },
+};
+
+function getSourceMeta(source) {
+  if (!source) return SOURCE_META.default;
+  const s = source.toLowerCase();
+  if (s.includes('wikipedia'))     return SOURCE_META.wikipedia;
+  if (s.includes('stackoverflow')) return SOURCE_META.stackoverflow;
+  if (s.includes('github'))        return SOURCE_META.github;
+  if (s.includes('reddit'))        return SOURCE_META.reddit;
+  if (s.includes('youtube'))       return SOURCE_META.youtube;
+  return SOURCE_META.default;
+}
+
+function highlightQuery(html, query) {
+  if (!html || !query || !query.trim()) return html || '';
+  try {
+    const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const re = new RegExp(`(${escaped})`, 'gi');
+    return html.replace(re, '<mark>$1</mark>');
+  } catch {
+    return html;
+  }
+}
 
 function getSearchMode(tab) {
   if (['wikipedia','reddit','youtube'].includes(tab)) return 'prose';
@@ -34,12 +66,17 @@ function getSearchMode(tab) {
   return 'all';
 }
 
+function getLoadingText(tab) {
+  if (tab === 'all') return 'Searching Wikipedia, StackOverflow, GitHub, Reddit, YouTube…';
+  const meta = SOURCE_META[tab];
+  return meta ? `Searching ${meta.label}…` : 'Searching…';
+}
+
 function isExternalResult(item) {
   const src = (item.source || '').toLowerCase();
   return !src.includes('local storage');
 }
 
-// FIX 4: filter out local storage results entirely
 function filterByTab(results, tab) {
   const external = results.filter(isExternalResult);
   if (tab === 'all') return external;
@@ -59,22 +96,27 @@ function cleanSource(source) {
 function SuggestionsDropdown({ suggestions, focusedIdx, onSelect, onHover }) {
   if (!suggestions.length) return null;
   return (
-    <div className="absolute left-0 right-0 top-full mt-2 bg-white/95 backdrop-blur-xl border border-[#40628A]/15 rounded-2xl shadow-2xl overflow-hidden z-50">
-      <ul>
+    <motion.div 
+      initial={{ opacity: 0, y: -8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -8 }}
+      transition={{ duration: 0.15, ease: 'easeOut' }}
+      className="absolute left-0 right-0 top-full mt-3 bg-white/95 backdrop-blur-xl border border-[#40628A]/15 rounded-2xl shadow-xl overflow-hidden z-50">
+      <ul className="py-1">
         {suggestions.map((s, i) => (
           <li key={s}
             onMouseDown={(e) => { e.preventDefault(); onSelect(s); }}
             onMouseEnter={() => onHover(i)}
             className={i === focusedIdx
-              ? 'px-5 py-3 cursor-pointer flex items-center gap-3 text-sm bg-[#40628A]/10 text-[#40628A]'
-              : 'px-5 py-3 cursor-pointer flex items-center gap-3 text-sm text-slate-700 hover:bg-[#40628A]/5'}
+              ? 'px-5 py-2.5 cursor-pointer flex items-center gap-3 text-sm bg-[#40628A]/10 text-[#40628A]'
+              : 'px-5 py-2.5 cursor-pointer flex items-center gap-3 text-sm text-slate-700 hover:bg-[#40628A]/5'}
           >
             <Search size={13} className="text-slate-400 shrink-0" />
             <span>{s}</span>
           </li>
         ))}
       </ul>
-    </div>
+    </motion.div>
   );
 }
 
@@ -110,12 +152,14 @@ function SearchInput({ query, setQuery, onSubmit, isLoading, suggestions, focuse
       >
         {isLoading ? <Loader2 size={14} className="animate-spin" /> : 'Search'}
       </button>
-      {showSuggestions && (
-        <SuggestionsDropdown suggestions={suggestions} focusedIdx={focusedIdx}
-          onSelect={(s) => { setQuery(s); setShowSuggestions(false); setFocusedIdx(-1); onSubmit(s); }}
-          onHover={setFocusedIdx}
-        />
-      )}
+      <AnimatePresence>
+        {showSuggestions && (
+          <SuggestionsDropdown suggestions={suggestions} focusedIdx={focusedIdx}
+            onSelect={(s) => { setQuery(s); setShowSuggestions(false); setFocusedIdx(-1); onSubmit(s); }}
+            onHover={setFocusedIdx}
+          />
+        )}
+      </AnimatePresence>
     </form>
   );
 }
@@ -186,6 +230,7 @@ function ResultsPage({ initialQuery, onGoHome }) {
   const [activeTab, setActiveTab] = useState('all');
   const [results, setResults] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [fetchDuration, setFetchDuration] = useState(null);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [focusedIdx, setFocusedIdx] = useState(-1);
   const suggestions = useSuggestions(query);
@@ -193,11 +238,16 @@ function ResultsPage({ initialQuery, onGoHome }) {
   const fetchResults = async (q, tab) => {
     if (!q.trim()) return;
     setIsLoading(true);
+    setFetchDuration(null);
+    const t0 = performance.now();
     try {
       const r = await fetch(getApiUrl() + '/search?q=' + encodeURIComponent(q.trim()) + '&mode=' + getSearchMode(tab));
       if (!r.ok) throw new Error();
       setResults((await r.json()).results || []);
-    } catch { setResults([]); } finally { setIsLoading(false); }
+    } catch { setResults([]); } finally {
+      setFetchDuration(((performance.now() - t0) / 1000).toFixed(2));
+      setIsLoading(false);
+    }
   };
 
   useEffect(() => { fetchResults(initialQuery, 'all'); }, []);
@@ -216,94 +266,143 @@ function ResultsPage({ initialQuery, onGoHome }) {
     <div className="min-h-screen flex flex-col font-sans relative" style={{ background: '#f6f3ec' }}>
       <MatrixBackground />
 
-      {/* FIX 2: Transparent navbar background */}
-      <div className="sticky top-0 z-30 w-full" style={{ background: 'transparent' }}>
-        {/* Top row: back arrow left, centered logo + search input */}
-        <div className="relative w-full px-4 sm:px-6 py-2 flex items-center justify-center">
-          {/* FIX 2: Back arrow button left positioned */}
-          <div className="absolute left-4 sm:left-6">
-            <button
-              onClick={onGoHome}
-              title="Go back home"
-              className="shrink-0 w-8 h-8 flex items-center justify-center rounded-full hover:bg-[#40628A]/10 text-slate-500 hover:text-[#40628A] transition-all active:scale-90"
-            >
-              <ArrowLeft size={18} strokeWidth={2} />
-            </button>
-          </div>
-
-          {/* FIX 2: Centered container with logo + search box */}
-          <div className="flex items-center gap-3 w-full max-w-2xl px-10 sm:px-12">
-            {/* Logo - FIX 4: Increased size to h-9 */}
-            <button onClick={onGoHome} className="shrink-0 cursor-pointer" title="Home">
-              <img src={logo} alt="Disee" className="h-9 w-auto" />
-            </button>
-
-            {/* Search bar */}
-            <div className="flex-1 relative">
-              <SearchInput query={query} setQuery={setQuery} onSubmit={handleSearch} isLoading={isLoading}
-                suggestions={suggestions} focusedIdx={focusedIdx} setFocusedIdx={setFocusedIdx}
-                showSuggestions={showSuggestions} setShowSuggestions={setShowSuggestions} autoFocus={false} />
-            </div>
-          </div>
+      {/* Sticky header — back arrow floats outside; search + tabs in a gradient-blur strip */}
+      <div className="sticky top-0 z-30 w-full">
+        {/* Back arrow — outside the blur area */}
+        <div className="absolute left-4 sm:left-6 top-3 z-40">
+          <button onClick={onGoHome} title="Go back home"
+            className="shrink-0 w-8 h-8 flex items-center justify-center rounded-full hover:bg-[#40628A]/10 text-slate-500 hover:text-[#40628A] transition-all active:scale-90">
+            <ArrowLeft size={18} strokeWidth={2} />
+          </button>
         </div>
 
-        {/* Filter tabs row - FIX 2: Centered layout */}
-        <div className="w-full pb-2 flex gap-2 overflow-x-auto no-scrollbar justify-center">
-          {TABS.map(({ id, label, icon: Icon }) => (
-            <button key={id} id={'filter-' + id} type="button" onClick={() => setActiveTab(id)}
-              className={activeTab === id
-                ? 'shrink-0 flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-xl border bg-[#40628A]/15 text-[#40628A] border-[#40628A]/30 transition-all'
-                : 'shrink-0 flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-xl border bg-white/50 text-slate-500 hover:bg-white/80 border-slate-300/40 hover:border-slate-300/60 transition-all'
-              }>
-              <Icon size={12} strokeWidth={2} className="shrink-0" />
-              <span>{label}</span>
-            </button>
-          ))}
+        {/* Content-width wrapper — uses a separate absolute blur-strip for background */}
+        <div className="w-full flex justify-center">
+          <div className="relative w-full max-w-3xl mx-auto px-4 sm:px-6 pt-2 pb-8 flex flex-col items-center">
+            {/* The fading blur background */}
+            <div className="blur-strip"></div>
+
+            {/* Logo + search bar row */}
+            <div className="flex items-center gap-3 w-full max-w-2xl px-6 sm:px-8 py-1.5 relative z-30">
+              <button onClick={onGoHome} className="shrink-0 cursor-pointer" title="Home">
+                <img src={logo} alt="Disee" className="h-9 w-auto" />
+              </button>
+              <div className="flex-1 relative">
+                <SearchInput query={query} setQuery={setQuery} onSubmit={handleSearch} isLoading={isLoading}
+                  suggestions={suggestions} focusedIdx={focusedIdx} setFocusedIdx={setFocusedIdx}
+                  showSuggestions={showSuggestions} setShowSuggestions={setShowSuggestions} autoFocus={false} />
+              </div>
+            </div>
+
+            {/* Filter tabs row */}
+            <div className="flex gap-2 overflow-x-auto no-scrollbar justify-center pt-1.5 relative z-10">
+              {TABS.map(({ id, label, icon: Icon, color }) => {
+                const isActive = activeTab === id;
+                return (
+                  <button key={id} id={'filter-' + id} type="button" onClick={() => setActiveTab(id)}
+                    className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-xl border transition-all"
+                    style={isActive
+                      ? { background: `${color}15`, color: color, borderColor: `${color}40`, fontWeight: 600 }
+                      : { background: 'rgba(255,255,255,0.5)', color: color, borderColor: 'rgba(203,213,225,0.4)' }
+                    }>
+                    <Icon size={12} strokeWidth={2} className="shrink-0" />
+                    <span>{label}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
         </div>
       </div>
 
-      {/* Results body - FIX 3: Tighter top padding */}
+      {/* Results body */}
       <div className="flex-1 w-full max-w-3xl mx-auto px-4 sm:px-6 pt-2 pb-20 flex flex-col gap-3 z-10">
+
+        {/* ── Result count + timing bar ── */}
+        {!isLoading && filtered.length > 0 && (
+          <motion.p initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="text-xs text-slate-400 px-1 py-1">
+            About <span className="font-semibold text-slate-500">{filtered.length}</span> result{filtered.length !== 1 ? 's' : ''}
+            {fetchDuration && <span> ({fetchDuration}s)</span>}
+          </motion.p>
+        )}
+
+        {/* ── Loading state ── */}
         {isLoading && (
-          <div className="flex flex-col items-center justify-center py-20 text-slate-400">
+          <div className="flex flex-col items-center justify-center py-20">
             <Loader2 size={32} className="animate-spin mb-4 text-[#40628A]" />
-            <p className="text-sm text-slate-500">Searching across all sources...</p>
+            <p className="text-sm text-slate-500 mb-3">{getLoadingText(activeTab)}</p>
+            <div className="loading-dots flex gap-1.5">
+              <span /><span /><span />
+            </div>
           </div>
         )}
+
+        {/* ── Empty state ── */}
         {!isLoading && filtered.length === 0 && (
-          <div className="glass-panel flex flex-col items-center justify-center py-14 text-center px-6 mt-4">
-            <p className="text-lg font-medium mb-1 text-slate-700">
+          <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }}
+            className="glass-panel flex flex-col items-center justify-center py-16 text-center px-8 mt-4">
+            <div className="w-14 h-14 rounded-2xl bg-[#40628A]/8 border border-[#40628A]/12 flex items-center justify-center mb-5">
+              <SearchX size={26} strokeWidth={1.5} className="text-[#40628A]/60" />
+            </div>
+            <p className="text-lg font-semibold mb-1 text-slate-700">
               No results for &ldquo;<span className="text-[#40628A]">{query}</span>&rdquo;
-              {activeTab !== 'all' && ' in ' + activeTab}
+              {activeTab !== 'all' && <span className="text-slate-400 font-normal"> in {activeTab}</span>}
             </p>
-            <p className="text-sm text-slate-400">Try a different filter or check your spelling.</p>
-          </div>
-        )}
-        {!isLoading && filtered.map((result, idx) => (
-          <motion.div key={result.title + idx}
-            initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.3, delay: 0.03 * idx }}
-            className="result-card group cursor-pointer p-5"
-            onClick={() => { if (result.url) window.open(result.url, '_blank'); }}>
-            <div className="flex items-start gap-4">
-              <div className="p-2.5 rounded-xl bg-[#40628A]/5 border border-[#40628A]/10 group-hover:bg-[#40628A]/10 transition-colors text-slate-400 group-hover:text-[#40628A] shrink-0">
-                <FileText size={18} strokeWidth={1.5} />
-              </div>
-              <div className="flex-1 min-w-0">
-                {result.url && (
-                  <p className="text-[11px] text-slate-400 mb-0.5 truncate">
-                    {(() => { try { const u = new URL(result.url); return u.hostname + u.pathname; } catch { return result.url; } })()}
-                  </p>
-                )}
-                <h3 className="text-base font-medium text-slate-800 group-hover:text-[#40628A] transition-colors mt-0.5 mb-1 flex items-center gap-2">
-                  <span className="truncate">{result.title}</span>
-                  <ExternalLink size={13} className="opacity-0 group-hover:opacity-60 transition-opacity shrink-0" />
-                </h3>
-                <p className="text-slate-500 text-sm leading-relaxed" dangerouslySetInnerHTML={{ __html: result.summary }} />
-              </div>
+            <p className="text-sm text-slate-400 mb-5 max-w-sm">We searched across all sources but couldn't find a match. Here are some things to try:</p>
+            <div className="flex flex-wrap justify-center gap-2">
+              <span className="text-xs bg-white/70 border border-slate-200/60 rounded-lg px-3 py-1.5 text-slate-500">✏️ Check your spelling</span>
+              <span className="text-xs bg-white/70 border border-slate-200/60 rounded-lg px-3 py-1.5 text-slate-500">🔍 Try a broader search term</span>
+              {activeTab !== 'all' && (
+                <button onClick={() => setActiveTab('all')}
+                  className="text-xs bg-[#40628A]/10 border border-[#40628A]/20 rounded-lg px-3 py-1.5 text-[#40628A] font-medium hover:bg-[#40628A]/15 transition-colors cursor-pointer">
+                  🌐 Switch to All sources
+                </button>
+              )}
             </div>
           </motion.div>
-        ))}
+        )}
+
+        {/* ── Result cards ── */}
+        {!isLoading && filtered.map((result, idx) => {
+          const meta = getSourceMeta(result.source);
+          const SourceIcon = meta.icon;
+          const highlightedSummary = highlightQuery(result.summary || '', query);
+          return (
+            <motion.div key={result.title + idx}
+              initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3, delay: Math.min(0.03 * idx, 0.3) }}
+              className="result-card group cursor-pointer p-5"
+              onClick={() => { if (result.url) window.open(result.url, '_blank'); }}>
+              <div className="flex items-start gap-4">
+                {/* Per-source icon */}
+                <div className="p-2.5 rounded-xl shrink-0 transition-colors"
+                  style={{ background: meta.bg, border: `1px solid ${meta.border}`, color: meta.color }}>
+                  <SourceIcon size={18} strokeWidth={1.5} />
+                </div>
+                <div className="flex-1 min-w-0">
+                  {/* Source badge + URL */}
+                  <div className="flex items-center gap-2 mb-0.5">
+                    <span className="source-badge" style={{ background: meta.bg, color: meta.color, border: `1px solid ${meta.border}` }}>
+                      {meta.label}
+                    </span>
+                    {result.url && (
+                      <span className="text-[11px] text-slate-400 truncate">
+                        {(() => { try { const u = new URL(result.url); return u.hostname; } catch { return ''; } })()}
+                      </span>
+                    )}
+                  </div>
+                  {/* Title */}
+                  <h3 className="text-base font-medium text-slate-800 group-hover:text-[#40628A] transition-colors mt-0.5 mb-1 flex items-center gap-2">
+                    <span className="truncate">{result.title}</span>
+                    <ExternalLink size={13} className="opacity-0 group-hover:opacity-60 transition-opacity shrink-0" />
+                  </h3>
+                  {/* Highlighted snippet */}
+                  <p className="text-slate-500 text-sm leading-relaxed line-clamp-2" dangerouslySetInnerHTML={{ __html: highlightedSummary }} />
+                </div>
+              </div>
+            </motion.div>
+          );
+        })}
       </div>
     </div>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -70,3 +70,65 @@
   -ms-overflow-style: none;  /* IE and Edge */
   scrollbar-width: none;  /* Firefox */
 }
+
+/* ─── Query-term highlight ─── */
+mark {
+  background: rgba(251, 191, 36, 0.25);
+  color: inherit;
+  border-radius: 3px;
+  padding: 0 2px;
+  font-weight: 500;
+}
+
+/* ─── Source badge pill ─── */
+.source-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 6px;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+/* ─── Pulse dot for loading state ─── */
+@keyframes pulse-dot {
+  0%, 80%, 100% { opacity: 0.3; transform: scale(0.8); }
+  40% { opacity: 1; transform: scale(1.1); }
+}
+.loading-dots span {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #40628A;
+  animation: pulse-dot 1.4s ease-in-out infinite;
+}
+.loading-dots span:nth-child(2) { animation-delay: 0.2s; }
+.loading-dots span:nth-child(3) { animation-delay: 0.4s; }
+
+/* ─── Gradient-fade blur strip (no hard edges on any side) ─── */
+.blur-strip {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+
+  /* Two mask layers intersected: horizontal fade + vertical fade */
+  -webkit-mask-image:
+    linear-gradient(to right, rgba(0,0,0,0), rgba(0,0,0,1) 6%, rgba(0,0,0,1) 94%, rgba(0,0,0,0)),
+    linear-gradient(to bottom, rgba(0,0,0,0), rgba(0,0,0,1) 2%, rgba(0,0,0,1) 40%, rgba(0,0,0,0) 100%);
+  -webkit-mask-composite: destination-in;
+
+  mask-image:
+    linear-gradient(to right, rgba(0,0,0,0), rgba(0,0,0,1) 6%, rgba(0,0,0,1) 94%, rgba(0,0,0,0)),
+    linear-gradient(to bottom, rgba(0,0,0,0), rgba(0,0,0,1) 2%, rgba(0,0,0,1) 40%, rgba(0,0,0,0) 100%);
+  mask-composite: intersect;
+
+  pointer-events: none;
+}


### PR DESCRIPTION
Hey! I wanted to contribute some UI/UX polish to the frontend on top of the awesome backend integrations added in this PR. 

### ✨ What's included in this update:
- **Source Badges & Dynamic Icons:** Result cards now feature colored source pill badges (e.g., Green for Wikipedia, Purple for GitHub) and dynamic Lucide icons (`BookOpen`, `Code2`, `GitBranch`, `MessageSquare`, `Video`) instead of a generic file icon.
- **Query Highlighting:** Search terms are now dynamically highlighted inside result snippets using `<mark>` with a soft amber background.
- **Improved Loading & Empty States:** Added contextual loading text (e.g., "Searching GitHub...") with an animated pulsing dots indicator. The empty state now features a friendly illustration and actionable suggestion chips to broaden the search or fix spelling.
- **Result Count Bar:** A subtle bar now displays the total filtered results and the fetch duration (e.g., "About 12 results (0.42s)").
- **Polished Sticky Navbar:** Converted the navbar to use a glassmorphism `.blur-strip`. It uses an intersected CSS mask gradient so the blur fades seamlessly into the background with no harsh edges when scrolling.
- **Dropdown Fixes:** Fixed the z-index stacking issue where the filter tabs overlapped the search suggestion dropdown. The suggestion dropdown also now uses `framer-motion` for a smooth slide-in/fade-out animation instead of appearing stiffly.

Tested locally and everything compiles perfectly. Let me know what you think! 🚀
